### PR TITLE
Add a simple check on the result

### DIFF
--- a/main.go
+++ b/main.go
@@ -105,6 +105,9 @@ func (b *Bea) Run(h *bridges.Helper) (interface{}, error) {
 	result := make(map[string]interface{})
 	result["result"] = sum / float64(3)
 
+	if result["result"] == 0 {
+		return nil, errors.New("Could not calculate value")
+	}
 	return result, err
 }
 


### PR DESCRIPTION
Prevents contracts from ingesting `0` when the endpoint is down.